### PR TITLE
Deployment files for heroku

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,9 @@
+# Heroku Buildpack
+With init.R and run.R in place, we can push directly to Heroku.
+However, we need to select a buildpack that tells Heroku how to handle the shiny app.
+We use: https://github.com/virtualstaticvoid/heroku-buildpack-r
+
+After creating a new project on Heroku, make sure to add the buildpack as a config var:
+heroku config:set BUILDPACK_URL=https://github.com/virtualstaticvoid/heroku-buildpack-r.git -a <heroku_project_name>
+
+That's it. Just push to Heroku.

--- a/init.R
+++ b/init.R
@@ -1,0 +1,10 @@
+# tell the buildpack to install the required packages:
+# using the helper caches the installed packages between deployments afaik.
+helpers.installPackages(
+  "exams",
+  "xtable",
+  "tth"
+)
+
+# special case of installing iuftools from source
+install.packages("./iuftools", repos = NULL, type="source")

--- a/run.R
+++ b/run.R
@@ -1,0 +1,7 @@
+library(shiny)
+port <- Sys.getenv('PORT')
+shiny::runApp(
+  appDir = getwd(),
+  host = '0.0.0.0',
+  port = as.numeric(port)
+)


### PR DESCRIPTION
The commit adds three files: init.R, run.R, and deployment.md
- init.R installs the necessary packages using the heroku buildpack helper function
- run.R defines the IP and port (from environment variable) to run the shiny app on
- deployment.md explains how to add a suitable buildpack to a heroku project, such that heroku knows how to handle the shiny app on deployment.